### PR TITLE
Enable auto_host_rewrite

### DIFF
--- a/example/book.yml
+++ b/example/book.yml
@@ -3,7 +3,7 @@
 version: 1
 dependencies:
   - name: 'user'
-    lb: 'user:8080'
+    lb: 'user-app:8080'
     tls: false
     connect_timeout_ms: 250
     circuit_breaker:
@@ -18,7 +18,7 @@ dependencies:
           num_retries: 3
           per_try_timeout_ms: 1000
   - name: 'ab-testing'
-    lb: 'ab-testing:8080'
+    lb: 'ab-testing-app:8080'
     tls: false
     connect_timeout_ms: 250
     circuit_breaker:

--- a/lib/kumonos/routes.rb
+++ b/lib/kumonos/routes.rb
@@ -25,6 +25,7 @@ module Kumonos
         base = {
           prefix: route['prefix'],
           timeout_ms: route['timeout_ms'],
+          auto_host_rewrite: true,
           cluster: name
         }
         with_retry = base.merge(

--- a/spec/clusters_spec.rb
+++ b/spec/clusters_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Kumonos::Clusters do
           connect_timeout_ms: 250,
           type: 'strict_dns',
           lb_type: 'round_robin',
-          hosts: [{ url: 'tcp://user:8080' }],
+          hosts: [{ url: 'tcp://user-app:8080' }],
           circuit_breakers: {
             default: {
               max_connections: 64,
@@ -27,7 +27,7 @@ RSpec.describe Kumonos::Clusters do
           connect_timeout_ms: 250,
           type: 'strict_dns',
           lb_type: 'round_robin',
-          hosts: [{ url: 'tcp://ab-testing:8080' }],
+          hosts: [{ url: 'tcp://ab-testing-app:8080' }],
           circuit_breakers: {
             default: {
               max_connections: 64,

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Kumonos::Routes do
             {
               prefix: '/',
               timeout_ms: 3000,
+              auto_host_rewrite: true,
               cluster: 'user',
               retry_policy: {
                 retry_on: '5xx,connect-failure,refused-stream',
@@ -34,6 +35,7 @@ RSpec.describe Kumonos::Routes do
             {
               prefix: '/',
               timeout_ms: 3000,
+              auto_host_rewrite: true,
               cluster: 'user'
             }
           ]
@@ -45,6 +47,7 @@ RSpec.describe Kumonos::Routes do
             {
               prefix: '/',
               timeout_ms: 3000,
+              auto_host_rewrite: true,
               cluster: 'ab-testing',
               retry_policy: {
                 retry_on: '5xx,connect-failure,refused-stream',
@@ -62,6 +65,7 @@ RSpec.describe Kumonos::Routes do
             {
               prefix: '/',
               timeout_ms: 3000,
+              auto_host_rewrite: true,
               cluster: 'ab-testing'
             }
           ]

--- a/test/app/app.rb
+++ b/test/app/app.rb
@@ -2,8 +2,8 @@ require 'sinatra'
 
 get '/' do
   sleep ENV['SLEEP'].to_f
-  raise 'error' if rand(0..ENV['ERROR_RATE'].to_i).zero?
-  "GET and #{ENV['RESPONSE'] || 'hello'}"
+  raise 'error' if ENV['ERROR_RATE'] && rand(0..ENV['ERROR_RATE'].to_i).zero?
+  "GET,#{env['HTTP_HOST']},#{ENV['RESPONSE']}"
 end
 
 post '/' do

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  user:
+  user-app:
     build: 'app'
     environment:
       RESPONSE: 'user'
@@ -8,7 +8,7 @@ services:
       ERROR_RATE: 5
     expose:
       - '8080'
-  ab-testing:
+  ab-testing-app:
     build: 'app'
     environment:
       RESPONSE: 'ab-testing'
@@ -29,8 +29,8 @@ services:
   envoy:
     image: 'envoyproxy/envoy:3213ef0ddef11f3dfee0883333050844a297cc5d'
     depends_on:
-      - 'user'
-      - 'ab-testing'
+      - 'user-app'
+      - 'ab-testing-app'
       - 'nginx'
       - 'socat'
     command:

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 require 'uri'
 
-def raise_error(_response)
+def raise_error
   raise('invalid response')
 end
 
@@ -9,14 +9,14 @@ envoy_url = URI('http://localhost:9211')
 
 Net::HTTP.start(envoy_url.host, envoy_url.port) do |http|
   response = http.get('/', Host: 'user')
-  p response
-  raise_error(response) if response.code != '200'
-  raise_error(response) if response.body != 'GET and user'
+  p response, response.body
+  raise_error if response.code != '200'
+  raise_error if response.body != 'GET,user-app,user'
 
   response = http.get('/', Host: 'ab-testing')
-  p response
-  raise_error(response) if response.code != '200'
-  raise_error(response) if response.body != 'GET and ab-testing'
+  p response, response.body
+  raise_error if response.code != '200'
+  raise_error if response.body != 'GET,ab-testing-app,ab-testing'
 
   puts 'pass'
   break


### PR DESCRIPTION
Some servers do not accept logical service names like "user" or
"auth-server" as a host/authoriry header. To dealt with them, rewrite
logical service names to concrete host name.