### PR TITLE
Use LB host value as a cluster name for DS

### DIFF
--- a/lib/kumonos/envoy.rb
+++ b/lib/kumonos/envoy.rb
@@ -88,13 +88,14 @@ module Kumonos
     DiscoverService = Struct.new(:refresh_delay_ms, :cluster) do
       class << self
         def build(h)
+          lb = h.fetch('lb')
           cluster = Cluster.new(
-            'discovery_service',
+            lb.split(':').first,
             'strict_dns',
             h.fetch('tls'),
             h.fetch('connect_timeout_ms'),
             'round_robin',
-            [{ 'url' => "tcp://#{h.fetch('lb')}" }]
+            [{ 'url' => "tcp://#{lb}" }]
           )
           new(h.fetch('refresh_delay_ms'), cluster)
         end

--- a/spec/envoy_spec.rb
+++ b/spec/envoy_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Kumonos::Envoy do
                 stat_prefix: 'egress_http',
                 access_log: [{ path: '/dev/stdout' }],
                 rds: {
-                  cluster: 'discovery_service',
+                  cluster: 'nginx',
                   route_config_name: 'default',
                   refresh_delay_ms: 30_000
                 },
@@ -51,7 +51,7 @@ RSpec.describe Kumonos::Envoy do
         ],
         cds: {
           cluster: {
-            name: 'discovery_service',
+            name: 'nginx',
             type: 'strict_dns',
             connect_timeout_ms: 1_000,
             lb_type: 'round_robin',
@@ -70,7 +70,7 @@ RSpec.describe Kumonos::Envoy do
     out = Kumonos::Envoy.generate(definition)
     ds_cluster = out.fetch(:cluster_manager).fetch(:cds).fetch(:cluster)
     expect(JSON.dump(ds_cluster)).to be_json_as(
-      name: 'discovery_service',
+      name: 'nginx',
       type: 'strict_dns',
       ssl_context: {},
       connect_timeout_ms: 1_000,


### PR DESCRIPTION
Envoy uses the name as a host/authority header. There are no
configurations like `auto_host_rewrite` in routes configuration.