### PR TITLE
Restrict DNS resolution family to v4

### DIFF
--- a/lib/kumonos/envoy.rb
+++ b/lib/kumonos/envoy.rb
@@ -166,7 +166,8 @@ module Kumonos
     Cluster = Struct.new(:name, :type, :tls, :connect_timeout_ms, :lb_type, :hosts) do
       class << self
         def build(h)
-          new(h.fetch('name'), h.fetch('type'), h.fetch('tls'), h.fetch('connect_timeout_ms'), h.fetch('lb_type'), h.fetch('hosts'))
+          new(h.fetch('name'), h.fetch('type'), h.fetch('tls'), h.fetch('connect_timeout_ms'),
+              h.fetch('lb_type'), h.fetch('hosts'))
         end
       end
 
@@ -181,6 +182,8 @@ module Kumonos
         h[:connect_timeout] = {
           seconds: connect_timeout_ms / 1000.0
         }
+        # Just work-around, it could be configurable.
+        h[:dns_lookup_family] = 'V4_ONLY'
         h
       end
     end

--- a/spec/envoy_spec.rb
+++ b/spec/envoy_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Kumonos::Envoy do
               seconds: 1
             },
             type: 'STRICT_DNS',
+            dns_lookup_family: 'V4_ONLY',
             lb_policy: 'ROUND_ROBIN',
             hosts: [
               { socket_address: { address: 'nginx', port_value: 80 } }
@@ -116,6 +117,7 @@ RSpec.describe Kumonos::Envoy do
     expect(JSON.dump(ds_cluster)).to be_json_as(
       name: 'nginx',
       type: 'STRICT_DNS',
+      dns_lookup_family: 'V4_ONLY',
       tls_context: {},
       connect_timeout: {
         seconds: 1.0


### PR DESCRIPTION
In AWS, we're using mostly IPv4, so temporally pin resolution to v4 family.