### PR TITLE
Require cluster_name

### DIFF
--- a/example/book.yml
+++ b/example/book.yml
@@ -3,6 +3,7 @@
 version: 1
 dependencies:
   - name: 'user'
+    cluster_name: 'user-development'
     lb: 'user-app:8080'
     tls: false
     connect_timeout_ms: 250
@@ -18,6 +19,7 @@ dependencies:
           num_retries: 3
           per_try_timeout_ms: 1000
   - name: 'ab-testing'
+    cluster_name: 'ab-testing-development'
     lb: 'ab-testing-app:8080'
     tls: false
     connect_timeout_ms: 250

--- a/example/example-with-tls.yml
+++ b/example/example-with-tls.yml
@@ -2,6 +2,7 @@
 version: 1
 dependencies:
   - name: 'example'
+    cluster_name: 'example-development'
     lb: 'example.com:443'
     tls: true
     connect_timeout_ms: 250

--- a/lib/kumonos/clusters.rb
+++ b/lib/kumonos/clusters.rb
@@ -13,7 +13,7 @@ module Kumonos
       class << self
         def build(h)
           new(
-            h.fetch('name'),
+            h.fetch('cluster_name'),
             h.fetch('connect_timeout_ms'),
             h.fetch('lb'),
             h.fetch('tls'),

--- a/lib/kumonos/routes.rb
+++ b/lib/kumonos/routes.rb
@@ -14,7 +14,8 @@ module Kumonos
       class << self
         def build(h)
           name = h.fetch('name')
-          routes = h.fetch('routes').map { |r| Route.build(r, name) }
+          cluster_name = h.fetch('cluster_name')
+          routes = h.fetch('routes').map { |r| Route.build(r, cluster_name) }
           new(name, [name], routes)
         end
       end

--- a/lib/schemas/service_definition.json
+++ b/lib/schemas/service_definition.json
@@ -23,6 +23,7 @@
         "additionalProperties": false,
         "required": [
           "name",
+          "cluster_name",
           "lb",
           "tls",
           "connect_timeout_ms",
@@ -34,6 +35,11 @@
             "type": "string",
             "id": "/properties/dependencies/items/properties/name",
             "default": "dependency-service-name"
+          },
+          "cluster_name": {
+            "type": "string",
+            "id": "/properties/dependencies/items/properties/name",
+            "default": "dependency-service-name-development"
           },
           "lb": {
             "type": "string",

--- a/spec/clusters_spec.rb
+++ b/spec/clusters_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Kumonos::Clusters do
     expect(out).to be_json_as(
       clusters: [
         {
-          name: 'user',
+          name: 'user-development',
           connect_timeout_ms: 250,
           type: 'strict_dns',
           lb_type: 'round_robin',
@@ -23,7 +23,7 @@ RSpec.describe Kumonos::Clusters do
           }
         },
         {
-          name: 'ab-testing',
+          name: 'ab-testing-development',
           connect_timeout_ms: 250,
           type: 'strict_dns',
           lb_type: 'round_robin',
@@ -50,7 +50,7 @@ RSpec.describe Kumonos::Clusters do
     expect(out).to be_json_as(
       clusters: [
         {
-          name: 'example',
+          name: 'example-development',
           connect_timeout_ms: 250,
           type: 'strict_dns',
           lb_type: 'round_robin',

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Kumonos::Routes do
               prefix: '/',
               timeout_ms: 3000,
               auto_host_rewrite: true,
-              cluster: 'user',
+              cluster: 'user-development',
               retry_policy: {
                 retry_on: '5xx,connect-failure,refused-stream',
                 num_retries: 3,
@@ -36,7 +36,7 @@ RSpec.describe Kumonos::Routes do
               prefix: '/',
               timeout_ms: 3000,
               auto_host_rewrite: true,
-              cluster: 'user'
+              cluster: 'user-development'
             }
           ]
         },
@@ -48,7 +48,7 @@ RSpec.describe Kumonos::Routes do
               prefix: '/',
               timeout_ms: 3000,
               auto_host_rewrite: true,
-              cluster: 'ab-testing',
+              cluster: 'ab-testing-development',
               retry_policy: {
                 retry_on: '5xx,connect-failure,refused-stream',
                 num_retries: 3,
@@ -66,7 +66,7 @@ RSpec.describe Kumonos::Routes do
               prefix: '/',
               timeout_ms: 3000,
               auto_host_rewrite: true,
-              cluster: 'ab-testing'
+              cluster: 'ab-testing-development'
             }
           ]
         }


### PR DESCRIPTION
And use the name for upstream cluster names to identify production clusters and staging or development clusters.